### PR TITLE
Refactor frontend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -43,7 +43,5 @@ jobs:
         run: |
           sam deploy --parameter-overrides \
             DomainName="moshan.fulder.dev" \
-            TmdbToken=${{ secrets.TMDB_TOKEN }}
-
-
-
+            TmdbToken=${{ secrets.TMDB_TOKEN }} \
+            LocalCognitoClient=${{ secrets.LOCAL_COGNITO_CLIENT }}

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ htmlcov/
 .aws-sam/
 
 scripts/
+
+configLocal.js

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -21,9 +21,9 @@
   <component name="ChangeListManager">
     <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/mal.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/mal.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/episode/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/episode/index.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/backlog.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/backlog.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/episode.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/episode.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/item.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/item.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/item/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/item/index.html" afterDir="false" />
     </list>

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -21,11 +21,22 @@
   <component name="ChangeListManager">
     <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/episode/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/episode/index.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/.eslintrc.yml" beforeDir="false" afterPath="$PROJECT_DIR$/docs/.eslintrc.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/common.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/common.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/mal.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/mal.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tmdb.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tmdb.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/backlog.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/backlog.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/callback.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/callback.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/auth.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/auth.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/token.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/token.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/episode.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/episode.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/index.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/index.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/item.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/item.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/item/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/item/index.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/results.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/results.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/unwatched.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/unwatched.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -20,21 +20,30 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.github/workflows/deploy.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/deploy.yml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/backlog.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/backlog.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/callback.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/callback.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/episode/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/episode/index.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/history.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/history.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/oauth_callback.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/oauth_callback.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/common.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/common.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/mal.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/mal.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tmdb.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tmdb.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/backlog.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/backlog.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/config.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/config.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" beforeDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/token.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/token.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/episode.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/episode.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/history.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/history.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/item.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/item.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/oauth_callback.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/callback.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/results.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/results.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/unwatched.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/unwatched.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/index.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/item/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/item/index.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/docs/package-lock.json" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/docs/package.json" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/results.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/results.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/unwatched.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/unwatched.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/template.yml" beforeDir="false" afterPath="$PROJECT_DIR$/template.yml" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
@@ -91,11 +100,11 @@
       <recent name="$PROJECT_DIR$/src/layers/databases/python" />
     </key>
     <key name="MoveFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/docs" />
       <recent name="$PROJECT_DIR$/docs/includes/js/api" />
       <recent name="$PROJECT_DIR$/src/lambdas/api/app" />
       <recent name="$PROJECT_DIR$" />
       <recent name="$PROJECT_DIR$/src/layers/databases" />
-      <recent name="$PROJECT_DIR$/src/lambdas/api" />
     </key>
   </component>
   <component name="RunManager" selected="Python tests.pytest in unittest">

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -20,6 +20,7 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/backlog.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/backlog.html" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/callback.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/callback.html" afterDir="false" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -20,31 +20,9 @@
   </component>
   <component name="ChangeListManager">
     <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
-      <change beforePath="$PROJECT_DIR$/.gitignore" beforeDir="false" afterPath="$PROJECT_DIR$/.gitignore" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/backlog.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/backlog.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/callback.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/callback.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/episode/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/episode/index.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/history.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/history.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/common.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/common.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/mal.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/mal.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tmdb.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tmdb.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/backlog.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/backlog.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/common/config.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/config.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" beforeDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/token.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/token.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/episode.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/episode.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/history.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/history.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/item.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/item.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/oauth_callback.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/callback.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/results.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/results.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/unwatched.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/unwatched.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/index.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/item/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/item/index.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/results.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/results.html" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/unwatched.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/unwatched.html" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -21,10 +21,11 @@
   <component name="ChangeListManager">
     <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/common.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/common.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/mal.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/mal.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" afterDir="false" />
-      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/config.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/config.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/tvmaze.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/item.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/item.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/item/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/item/index.html" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -19,7 +19,23 @@
     <select />
   </component>
   <component name="ChangeListManager">
-    <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="" />
+    <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/.github/workflows/deploy.yml" beforeDir="false" afterPath="$PROJECT_DIR$/.github/workflows/deploy.yml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/backlog.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/backlog.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/callback.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/callback.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/episode/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/episode/index.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/history.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/history.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/navbar.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/oauth_callback.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/oauth_callback.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/index.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/item/index.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/item/index.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/package-lock.json" beforeDir="false" afterPath="$PROJECT_DIR$/docs/package-lock.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/package.json" beforeDir="false" afterPath="$PROJECT_DIR$/docs/package.json" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/results.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/results.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/unwatched.html" beforeDir="false" afterPath="$PROJECT_DIR$/docs/unwatched.html" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/template.yml" beforeDir="false" afterPath="$PROJECT_DIR$/template.yml" afterDir="false" />
+    </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />
     <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
@@ -55,24 +71,24 @@
     <option name="hideEmptyMiddlePackages" value="true" />
     <option name="showLibraryContents" value="true" />
   </component>
-  <component name="PropertiesComponent">{
-  &quot;keyToString&quot;: {
-    &quot;last_opened_file_path&quot;: &quot;/home/michal/git/moshan&quot;,
-    &quot;settings.editor.selected.configurable&quot;: &quot;copyright.filetypes.Python&quot;
+  <component name="PropertiesComponent"><![CDATA[{
+  "keyToString": {
+    "last_opened_file_path": "/home/michal/git/moshan/docs/includes/js/common",
+    "settings.editor.selected.configurable": "copyright.filetypes.Python"
   },
-  &quot;keyToStringList&quot;: {
-    &quot;com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File&quot;: [
-      &quot;PUML&quot;
+  "keyToStringList": {
+    "com.intellij.ide.scratch.ScratchImplUtil$2/New Scratch File": [
+      "PUML"
     ]
   }
-}</component>
+}]]></component>
   <component name="RecentsManager">
     <key name="CopyFile.RECENT_KEYS">
+      <recent name="$PROJECT_DIR$/docs/includes/js/common" />
       <recent name="$APPLICATION_CONFIG_DIR$/scratches" />
       <recent name="$PROJECT_DIR$/scripts" />
       <recent name="$PROJECT_DIR$/src/lambdas/api/watch_histories" />
       <recent name="$PROJECT_DIR$/src/layers/databases/python" />
-      <recent name="$PROJECT_DIR$/src/layers/api/python" />
     </key>
     <key name="MoveFile.RECENT_KEYS">
       <recent name="$PROJECT_DIR$/docs/includes/js/api" />
@@ -233,9 +249,9 @@
       <method v="2" />
     </configuration>
     <list>
-      <item itemvalue="Python.cleanup_downloads" />
       <item itemvalue="Python.migrate_anime_episodes_from_watchhistory" />
       <item itemvalue="Python.migrate_show_episodes_from_watchhistory" />
+      <item itemvalue="Python.cleanup_downloads" />
       <item itemvalue="Python.scratch_41" />
       <item itemvalue="Python.scratch_42" />
       <item itemvalue="Python tests.pytest for test_models.test_parse_episode" />

--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -21,8 +21,10 @@
   <component name="ChangeListManager">
     <list default="true" id="0ab0434b-1335-4890-8c69-62c5f233c642" name="Default Changelist" comment="">
       <change beforePath="$PROJECT_DIR$/.idea/workspace.xml" beforeDir="false" afterPath="$PROJECT_DIR$/.idea/workspace.xml" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/api/common.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/common.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/api/moshan.js" afterDir="false" />
       <change beforePath="$PROJECT_DIR$/docs/includes/js/common/config.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/common/config.js" afterDir="false" />
+      <change beforePath="$PROJECT_DIR$/docs/includes/js/item.js" beforeDir="false" afterPath="$PROJECT_DIR$/docs/includes/js/item.js" afterDir="false" />
     </list>
     <option name="SHOW_DIALOG" value="false" />
     <option name="HIGHLIGHT_CONFLICTS" value="true" />

--- a/docs/.eslintrc.yml
+++ b/docs/.eslintrc.yml
@@ -5,6 +5,7 @@ env:
   jquery: false
 parserOptions:
   ecmaVersion: 12
+  sourceType: module
 rules:
     semi:
       - error

--- a/docs/backlog.html
+++ b/docs/backlog.html
@@ -108,6 +108,7 @@
 </footer>
 
 <!-- Moshan scripts -->
+<script src="/includes/js/common/config.js"></script>
 <script src="/includes/js/common/navbar.js"></script>
 
 <script src="/includes/js/backlog.js"></script>

--- a/docs/backlog.html
+++ b/docs/backlog.html
@@ -18,76 +18,15 @@
     <!-- Moshan CSS -->
     <link rel="stylesheet" href="/includes/css/style.css">
 
-    <!-- Moshan scripts -->
-    <script src="/includes/js/common/token.js"></script>
-
-    <script src="/includes/js/api/common.js"></script>
-
-    <script src="/includes/js/api/moshan.js"></script>
-    <script src="/includes/js/api/tvmaze.js"></script>
-    <script src="/includes/js/api/tmdb.js"></script>
-    <script src="/includes/js/api/mal.js"></script>
-
     <!-- Font Awesome Icons -->
     <script src="https://kit.fontawesome.com/f013262c1a.js" crossorigin="anonymous"></script>
 
     <title>Moshan - Backlog</title>
 </head>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
-    <a class="navbar-brand" href="/index.html">
-      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
-            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarToggler">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/index.html">Home</a>
-            </li>
-        </ul>
-
-        <ul class="navbar-nav">
-            <li class="nav-item mr-3">
-                <form class="form-inline" action="/results.html">
-                    <div class="input-group">
-                        <input type="text" class="form-control" placeholder="Search" name="search">
-                        <div class="input-group-prepend">
-                            <button class="btn btn-success" type="submit">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </li>
-
-            <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button"
-                   data-bs-toggle="dropdown" aria-expanded="false"></a>
-                <div class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
-                    <a class="dropdown-item" href="/unwatched.html">Unwatched</a>
-                    <a class="dropdown-item" href="/backlog.html">Backlog</a>
-                    <a class="dropdown-item" href="/history.html">History</a>
-                    <div class="dropdown-divider"></div>
-                    <a class="dropdown-item text-danger" onclick="logout()" href="#">Logout</a>
-                </div>
-            </li>
-        </ul>
-        <button id="loginButton" onclick="authorize()" class="btn btn-outline-success nav-item" type="submit">
-            <i class="fas fa-sign-in-alt"></i>
-            Login
-        </button>
-    </div>
-</nav>
+<div id="navbar"></div>
 
 <body>
-<div id="logInAlert" class="alert alert-danger d-none" role="alert">
-    Need to be logged in before accessing watch history
-</div>
-
 <table class="table table-hover">
   <thead>
     <tr>
@@ -108,10 +47,7 @@
 </footer>
 
 <!-- Moshan scripts -->
-<script src="/includes/js/common/config.js"></script>
-<script src="/includes/js/common/navbar.js"></script>
-
-<script src="/includes/js/backlog.js"></script>
+<script type="module" src="/includes/js/backlog.js"></script>
 
 <!-- Boostrap JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/docs/callback.html
+++ b/docs/callback.html
@@ -9,10 +9,6 @@
 <body>
     <p id="login_status"></p>
     <meta http-equiv="refresh" content="1;url=index.html"/>
-
-    <script src="/includes/js/common/config.js"></script>
-
-    <script src="/includes/js/common/navbar.js"></script>
-    <script src="/includes/js/oauth_callback.js"></script>
+    <script type="module" src="/includes/js/callback.js"></script>
 </body>
 </html>

--- a/docs/callback.html
+++ b/docs/callback.html
@@ -8,7 +8,9 @@
 </head>
 <body>
     <p id="login_status"></p>
-    <meta http-equiv="refresh" content="2;url=index.html"/>
+    <meta http-equiv="refresh" content="1;url=index.html"/>
+
+    <script src="/includes/js/common/config.js"></script>
 
     <script src="/includes/js/common/navbar.js"></script>
     <script src="/includes/js/oauth_callback.js"></script>

--- a/docs/episode/index.html
+++ b/docs/episode/index.html
@@ -18,9 +18,6 @@
     <!-- Moshan CSS -->
     <link rel="stylesheet" href="/includes/css/style.css">
 
-    <!-- Moshan scripts -->
-    <script src="/includes/js/common/token.js"></script>
-
     <!-- Font Awesome Icons -->
     <script src="https://kit.fontawesome.com/f013262c1a.js" crossorigin="anonymous"></script>
 
@@ -31,53 +28,7 @@
     <title>Moshan - Episode</title>
 </head>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
-    <a class="navbar-brand" href="/index.html">
-      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
-            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarToggler">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/index.html">Home</a>
-            </li>
-        </ul>
-
-        <ul class="navbar-nav">
-            <li class="nav-item mr-3">
-                <form class="form-inline" action="/results.html">
-                    <div class="input-group">
-                        <input type="text" class="form-control" placeholder="Search" name="search">
-                        <div class="input-group-prepend">
-                            <button class="btn btn-success" type="submit">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </li>
-
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"></a>
-              <ul class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
-                <li><a class="dropdown-item" href="/unwatched.html">Unwatched</a></li>
-                <li><a class="dropdown-item" href="/backlog.html">Backlog</a></li>
-                <li><a class="dropdown-item" href="/history.html">History</a></li>
-                <li><hr class="dropdown-divider"></li>
-                <li><a class="dropdown-item text-danger" onclick="logout()" href="#">Logout</a></li>
-              </ul>
-            </li>
-        </ul>
-        <button id="loginButton" onclick="authorize()" class="btn btn-outline-success nav-item" type="submit">
-            <i class="fas fa-sign-in-alt"></i>
-            Login
-        </button>
-    </div>
-</nav>
+<div id="navbar"></div>
 
 <body>
 
@@ -120,16 +71,7 @@
 </footer>
 
 <!-- Moshan scripts -->
-<script src="/includes/js/common/config.js"></script>
-<script src="/includes/js/common/navbar.js"></script>
-
-<script src="/includes/js/api/common.js"></script>
-
-<script src="/includes/js/api/moshan.js"></script>
-<script src="/includes/js/api/tvmaze.js"></script>
-<script src="/includes/js/api/mal.js"></script>
-
-<script src="/includes/js/episode.js"></script>
+<script type="module" src="/includes/js/episode.js"></script>
 
 <!-- Boostrap JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/docs/episode/index.html
+++ b/docs/episode/index.html
@@ -120,6 +120,7 @@
 </footer>
 
 <!-- Moshan scripts -->
+<script src="/includes/js/common/config.js"></script>
 <script src="/includes/js/common/navbar.js"></script>
 
 <script src="/includes/js/api/common.js"></script>

--- a/docs/episode/index.html
+++ b/docs/episode/index.html
@@ -48,8 +48,8 @@
       </div>
 
       <div class="col-md-4 col-10 mt-1">
-          <button id="add_button" class="btn btn-success d-none" onclick="addEpisode()"><i class="fa fa-plus"></i> Add</button>
-          <button id="remove_button" class="btn btn-danger d-none" onclick="removeEpisode()"><i class="fa fa-minus"></i> Remove</button>
+          <button id="addButton" class="btn btn-success d-none"><i class="fa fa-plus"></i> Add</button>
+          <button id="removeButton" class="btn btn-danger d-none"><i class="fa fa-minus"></i> Remove</button>
           <b>Watched</b>:<span id="watched_amount"></span>
           <div class="input-group input-group-sm pt-1">
             <div class="input-group-prepend">
@@ -58,7 +58,7 @@
 
             <input id="flatpickr" type="text" class="form-control" ${!episodeAired ? 'disabled' : ''}>
             <div class="input-group-append">
-              <button class="btn btn-primary" type="button" onclick="setCurrentWatchDate()"><i class="fas fa-calendar-day"></i></button><button class="btn btn-danger" type="button" onclick="removeWatchDate()"><i class="far fa-calendar-times"></i></button>
+              <button id="setDateButton" class="btn btn-primary" type="button"><i class="fas fa-calendar-day"></i></button><button id="removeDateButton" class="btn btn-danger" type="button"><i class="far fa-calendar-times"></i></button>
             </div>
           </div>
       </div>

--- a/docs/history.html
+++ b/docs/history.html
@@ -107,6 +107,7 @@
 </footer>
 
 <!-- Moshan scripts -->
+<script src="/includes/js/common/config.js"></script>
 <script src="/includes/js/common/navbar.js"></script>
 
 <script src="/includes/js/history.js"></script>

--- a/docs/history.html
+++ b/docs/history.html
@@ -18,71 +18,13 @@
     <!-- Moshan CSS -->
     <link rel="stylesheet" href="/includes/css/style.css">
 
-    <!-- Moshan scripts -->
-    <script src="/includes/js/common/token.js"></script>
-
-    <script src="/includes/js/api/common.js"></script>
-
-    <script src="/includes/js/api/moshan.js"></script>
-    <script src="/includes/js/api/tvmaze.js"></script>
-    <script src="/includes/js/api/tmdb.js"></script>
-    <script src="/includes/js/api/mal.js"></script>
-
-
     <!-- Font Awesome Icons -->
     <script src="https://kit.fontawesome.com/f013262c1a.js" crossorigin="anonymous"></script>
 
     <title>Moshan - History</title>
 </head>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
-    <a class="navbar-brand" href="/index.html">
-      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
-            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarToggler">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/index.html">Home</a>
-            </li>
-        </ul>
-
-        <ul class="navbar-nav">
-            <li class="nav-item mr-3">
-                <form class="form-inline" action="/results.html">
-                    <div class="input-group">
-                        <input type="text" class="form-control" placeholder="Search" name="search">
-                        <div class="input-group-prepend">
-                            <button class="btn btn-success" type="submit">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </li>
-
-            <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button"
-                   data-bs-toggle="dropdown" aria-expanded="false"></a>
-                <div class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
-                    <a class="dropdown-item" href="/unwatched.html">Unwatched</a>
-                    <a class="dropdown-item" href="/backlog.html">Backlog</a>
-                    <a class="dropdown-item" href="/history.html">History</a>
-                    <div class="dropdown-divider"></div>
-                    <a class="dropdown-item text-danger" onclick="logout()" href="#">Logout</a>
-                </div>
-            </li>
-        </ul>
-        <button id="loginButton" onclick="authorize()" class="btn btn-outline-success nav-item" type="submit">
-            <i class="fas fa-sign-in-alt"></i>
-            Login
-        </button>
-    </div>
-</nav>
+<div id="navbar"></div>
 
 <body>
 <div id="logInAlert" class="alert alert-danger d-none" role="alert">
@@ -107,10 +49,7 @@
 </footer>
 
 <!-- Moshan scripts -->
-<script src="/includes/js/common/config.js"></script>
-<script src="/includes/js/common/navbar.js"></script>
-
-<script src="/includes/js/history.js"></script>
+<script type="module" src="/includes/js/history.js"></script>
 
 <!-- Boostrap JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/docs/includes/html/navbar.html
+++ b/docs/includes/html/navbar.html
@@ -1,0 +1,53 @@
+<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
+    <a class="navbar-brand" href="/index.html">
+      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
+    </a>
+    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
+            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
+          <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarToggler">
+        <ul class="navbar-nav mr-auto">
+            <li class="nav-item">
+                <a class="nav-link" href="/index.html">Moshan</a>
+            </li>
+        </ul>
+
+        <ul class="navbar-nav">
+            <li class="nav-item mr-3">
+                <form class="form-inline" action="/results.html">
+                    <div class="input-group">
+                        <input type="text" class="form-control" placeholder="Search" name="search">
+                        <div class="input-group-prepend">
+                            <button class="btn btn-success" type="submit">
+                                <i class="fas fa-search"></i>
+                            </button>
+                        </div>
+                    </div>
+                </form>
+            </li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"></a>
+              <ul class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
+                <li><a class="dropdown-item" href="/unwatched.html">Unwatched</a></li>
+                <li><a class="dropdown-item" href="/backlog.html">Backlog</a></li>
+                <li><a class="dropdown-item" href="/history.html">History</a></li>
+                <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item text-danger" id="logoutButton" href="#">Logout</a></li>
+              </ul>
+            </li>
+        </ul>
+        <button id="loginButton" class="btn btn-outline-success nav-item" type="submit">
+            <i class="fas fa-sign-in-alt"></i>
+            Login
+        </button>
+    </div>
+</nav>
+
+<div id="logInAlert" class="alert alert-danger d-none" role="alert">
+    Please log in before accessing this page
+</div>
+<!--<div id="itemsLoadingAlert" class="alert alert-warning d-none" role="alert">-->
+<!--    Some watch history items are still loading-->
+<!--</div>-->

--- a/docs/includes/js/api/common.js
+++ b/docs/includes/js/api/common.js
@@ -1,12 +1,9 @@
-import {MalApi} from './mal.js'
-import {TmdbApi} from './tmdb.js'
-import {TvMazeApi} from './tvmaze.js'
-import {checkToken, accessToken} from '../common/token.js'
+import {MalApi} from './mal.js';
+import {TmdbApi} from './tmdb.js';
+import {TvMazeApi} from './tvmaze.js';
+import {checkToken, accessToken} from '../common/token.js';
 
 let checkTokenPromise = null;
-
-/* exported collectionNames */
-const collectionNames = ['movie', 'show', 'anime'];
 
 /* exported axiosTokenInterceptor */
 export async function axiosTokenInterceptor (config) {

--- a/docs/includes/js/api/common.js
+++ b/docs/includes/js/api/common.js
@@ -37,13 +37,14 @@ export function MoshanItem(id, poster, title, releaseDate, status, synopsis, has
   this.review = review;
 }
 
-export function Review(overview, review, rating, datesWatched, createdAt, updatedAt) {
+export function Review(overview, review, rating, datesWatched, createdAt, updatedAt, status) {
     this.overview = overview;
     this.review = review;
     this.rating = rating;
     this.datesWatched = datesWatched;
     this.createdAt = createdAt;
     this.updatedAt = updatedAt;
+    this.status = status;
 }
 
 export function MoshanEpisodes(episodes, total_pages) {

--- a/docs/includes/js/api/common.js
+++ b/docs/includes/js/api/common.js
@@ -25,7 +25,7 @@ export function MoshanItems(collection_name) {
   this.items = [];
 }
 
-export function MoshanItem(id, poster, title, releaseDate, status, synopsis, hasEpisodes, apiName, review) {
+export function MoshanItem(id, poster, title, releaseDate, status, synopsis, hasEpisodes, apiName, review={}) {
   this.id = id;
   this.imageUrl = poster;
   this.title = title;
@@ -34,11 +34,16 @@ export function MoshanItem(id, poster, title, releaseDate, status, synopsis, has
   //this.synopsis = synopsis;
   this.hasEpisodes = hasEpisodes;
   this.apiName = apiName;
-  this.review = review
+  this.review = review;
 }
 
-function Review(createdAt, overview, review, rating, datesWatched, updatedAt, backlogDate, latestWatchDate, epProgress, watchedEps, specialProgress, watchedSpecials) {
-
+export function Review(overview, review, rating, datesWatched, createdAt, updatedAt) {
+    this.overview = overview;
+    this.review = review;
+    this.rating = rating;
+    this.datesWatched = datesWatched;
+    this.createdAt = createdAt;
+    this.updatedAt = updatedAt;
 }
 
 export function MoshanEpisodes(episodes, total_pages) {

--- a/docs/includes/js/api/common.js
+++ b/docs/includes/js/api/common.js
@@ -1,10 +1,15 @@
+import {MalApi} from './mal.js'
+import {TmdbApi} from './tmdb.js'
+import {TvMazeApi} from './tvmaze.js'
+import {checkToken, accessToken} from '../common/token.js'
+
 let checkTokenPromise = null;
 
 /* exported collectionNames */
 const collectionNames = ['movie', 'show', 'anime'];
 
 /* exported axiosTokenInterceptor */
-async function axiosTokenInterceptor (config) {
+export async function axiosTokenInterceptor (config) {
   if (checkTokenPromise === null) {
     checkTokenPromise = checkToken();
   }
@@ -15,32 +20,33 @@ async function axiosTokenInterceptor (config) {
   return config;
 }
 
-/* exported MoshanItems */
-function MoshanItems(collection_name) {
+export function MoshanItems(collection_name) {
   this.collection_name = collection_name;
   this.items = [];
 }
 
-/* exported MoshanItem */
-function MoshanItem(id, poster, title, start_date, status, synopsis, has_episodes, api_name) {
+export function MoshanItem(id, poster, title, releaseDate, status, synopsis, hasEpisodes, apiName, review) {
   this.id = id;
-  this.poster = poster;
+  this.imageUrl = poster;
   this.title = title;
-  this.start_date = start_date;
+  this.releaseDate = releaseDate;
   this.status = status;
-  this.synopsis = synopsis;
-  this.has_episodes = has_episodes;
-  this.api_name = api_name;
+  //this.synopsis = synopsis;
+  this.hasEpisodes = hasEpisodes;
+  this.apiName = apiName;
+  this.review = review
 }
 
-/* exported MoshanEpisodes */
-function MoshanEpisodes(episodes, total_pages) {
+function Review(createdAt, overview, review, rating, datesWatched, updatedAt, backlogDate, latestWatchDate, epProgress, watchedEps, specialProgress, watchedSpecials) {
+
+}
+
+export function MoshanEpisodes(episodes, total_pages) {
   this.episodes = episodes;
   this.total_pages = total_pages;
 }
 
-/* exported MoshanEpisode */
-function MoshanEpisode(id, number, title, air_date, previous_id, next_id, extra_ep=false) {
+export function MoshanEpisode(id, number, title, air_date, previous_id, next_id, extra_ep=false) {
   this.id = id;
   this.number = number;
   this.title = title;
@@ -52,8 +58,7 @@ function MoshanEpisode(id, number, title, air_date, previous_id, next_id, extra_
   this.extra_ep = extra_ep;
 }
 
-/* exported getApiByName */
-function getApiByName(name) {
+export function getApiByName(name) {
   switch(name) {
     case 'mal':
       return new MalApi();

--- a/docs/includes/js/api/mal.js
+++ b/docs/includes/js/api/mal.js
@@ -1,4 +1,4 @@
-import {MoshanItems, MoshanItem, MoshanEpisodes, MoshanEpisode} from './common.js'
+import {MoshanItems, MoshanItem, MoshanEpisodes, MoshanEpisode} from './common.js';
 
 export class MalApi {
   constructor () {

--- a/docs/includes/js/api/mal.js
+++ b/docs/includes/js/api/mal.js
@@ -1,6 +1,6 @@
-/* global axios, MoshanItem */
-/* exported MalApi */
-class MalApi {
+import {MoshanItems, MoshanItem, MoshanEpisode} from './common.js'
+
+export class MalApi {
   constructor () {
     this.apiAxios = axios.create({
       baseURL: 'https://api.jikan.moe/v4/',

--- a/docs/includes/js/api/mal.js
+++ b/docs/includes/js/api/mal.js
@@ -1,4 +1,4 @@
-import {MoshanItems, MoshanItem, MoshanEpisode} from './common.js'
+import {MoshanItems, MoshanItem, MoshanEpisodes, MoshanEpisode} from './common.js'
 
 export class MalApi {
   constructor () {

--- a/docs/includes/js/api/moshan.js
+++ b/docs/includes/js/api/moshan.js
@@ -58,12 +58,19 @@ export class MoshanApi {
         ret.data.datesWatched,
         ret.data.createdAt,
         ret.data.updatedAt,
+        ret.data.status,
     )
 
-    console.debug(review);
+    let poster = ret.data.apiCache.imageUrl;
+    if (!ret.data.apiCache.imageUrl.includes("http")) {
+      poster = `https://image.tmdb.org/t/p/w500/${ret.data.apiCache.imageUrl}`;
+    }
+
+    console.log(ret.data)
+
     return new MoshanItem(
       ret.data.apiId,
-      ret.data.apiCache.imageUrl,
+      poster,
       ret.data.apiCache.title,
       ret.data.apiCache.releaseDate,
       ret.data.apiCache.status,

--- a/docs/includes/js/api/moshan.js
+++ b/docs/includes/js/api/moshan.js
@@ -1,4 +1,4 @@
-import {axiosTokenInterceptor, MoshanItem} from './common.js'
+import {axiosTokenInterceptor, MoshanItem, Review} from './common.js'
 
 export class MoshanApi {
   constructor () {
@@ -48,8 +48,30 @@ export class MoshanApi {
     return this.apiAxios.post('/items', data);
   }
 
-  getItem (qParams) {
-    return this.apiAxios.get(`/items/${qParams.api_name}/${qParams.api_id}`);
+  async getItem (qParams) {
+    const ret = await this.apiAxios.get(`/items/${qParams.api_name}/${qParams.api_id}`);
+
+    const review = new Review(
+        ret.data.overview,
+        ret.data.review,
+        ret.data.rating,
+        ret.data.datesWatched,
+        ret.data.createdAt,
+        ret.data.updatedAt,
+    )
+
+    console.debug(review);
+    return new MoshanItem(
+      ret.data.apiId,
+      ret.data.apiCache.imageUrl,
+      ret.data.apiCache.title,
+      ret.data.apiCache.releaseDate,
+      ret.data.apiCache.status,
+      "",
+      "epCount" in ret.data.apiCache,
+      "moshan",
+      review,
+    );
   }
 
   updateItem (qParams, overview, review, status = '', rating = '', watchDates = []) {

--- a/docs/includes/js/api/moshan.js
+++ b/docs/includes/js/api/moshan.js
@@ -1,4 +1,4 @@
-import {axiosTokenInterceptor, MoshanItem, Review} from './common.js'
+import {axiosTokenInterceptor, MoshanItem, Review} from './common.js';
 
 export class MoshanApi {
   constructor () {
@@ -58,15 +58,15 @@ export class MoshanApi {
         ret.data.datesWatched,
         ret.data.createdAt,
         ret.data.updatedAt,
-        ret.data.status,
-    )
+        ret.data.status
+    );
 
     let poster = ret.data.apiCache.imageUrl;
-    if (!ret.data.apiCache.imageUrl.includes("http")) {
+    if (!ret.data.apiCache.imageUrl.includes('http')) {
       poster = `https://image.tmdb.org/t/p/w500/${ret.data.apiCache.imageUrl}`;
     }
 
-    console.log(ret.data)
+    console.log(ret.data);
 
     return new MoshanItem(
       ret.data.apiId,
@@ -74,10 +74,10 @@ export class MoshanApi {
       ret.data.apiCache.title,
       ret.data.apiCache.releaseDate,
       ret.data.apiCache.status,
-      "",
-      "epCount" in ret.data.apiCache,
-      "moshan",
-      review,
+      '',
+      'epCount' in ret.data.apiCache,
+      'moshan',
+      review
     );
   }
 

--- a/docs/includes/js/api/moshan.js
+++ b/docs/includes/js/api/moshan.js
@@ -1,6 +1,6 @@
-/* global axios, axiosTokenInterceptor */
-/* exported MoshanApi */
-class MoshanApi {
+import {axiosTokenInterceptor, MoshanItem} from './common.js'
+
+export class MoshanApi {
   constructor () {
     this.apiAxios = axios.create({
       baseURL: 'https://api.moshan.fulder.dev',

--- a/docs/includes/js/api/tmdb.js
+++ b/docs/includes/js/api/tmdb.js
@@ -1,4 +1,4 @@
-import {MoshanItems, MoshanItem} from './common.js'
+import {MoshanItems, MoshanItem} from './common.js';
 
 export class TmdbApi {
   constructor () {

--- a/docs/includes/js/api/tmdb.js
+++ b/docs/includes/js/api/tmdb.js
@@ -1,6 +1,6 @@
-/* global axios */
-/* exported TmdbApi */
-class TmdbApi {
+import {MoshanItems, MoshanItem} from './common.js'
+
+export class TmdbApi {
   constructor () {
     this.apiAxios = axios.create({
       baseURL: 'https://api.themoviedb.org/3',

--- a/docs/includes/js/api/tvmaze.js
+++ b/docs/includes/js/api/tvmaze.js
@@ -1,4 +1,4 @@
-import {MoshanItems, MoshanItem, MoshanEpisodes, MoshanEpisode} from './common.js'
+import {MoshanItems, MoshanItem, MoshanEpisodes, MoshanEpisode} from './common.js';
 
 export class TvMazeApi {
   constructor () {

--- a/docs/includes/js/api/tvmaze.js
+++ b/docs/includes/js/api/tvmaze.js
@@ -1,4 +1,4 @@
-import {MoshanItems, MoshanItem, MoshanEpisode} from './common.js'
+import {MoshanItems, MoshanItem, MoshanEpisodes, MoshanEpisode} from './common.js'
 
 export class TvMazeApi {
   constructor () {

--- a/docs/includes/js/api/tvmaze.js
+++ b/docs/includes/js/api/tvmaze.js
@@ -1,6 +1,6 @@
-/* global axios */
-/* exported TvMazeApi */
-class TvMazeApi {
+import {MoshanItems, MoshanItem, MoshanEpisode} from './common.js'
+
+export class TvMazeApi {
   constructor () {
     this.apiAxios = axios.create({
       baseURL: 'https://api.tvmaze.com',

--- a/docs/includes/js/backlog.js
+++ b/docs/includes/js/backlog.js
@@ -40,11 +40,9 @@ async function createTableRows(cursor='') {
     //   moshanItems[`${responses[i].api_name}_${responses[i].id}`] = responses[i];
     // }
 
-    let html = '';
     for (let i=0; i< items.length; i++) {
-      html += createRow(items[i]);
+      createRow(items[i]);
     }
-    document.getElementById('backlog-table-body').innerHTML += html;
 }
 
 
@@ -63,17 +61,33 @@ function createRow(watchHistoryItem) {
     apiCache.releaseDate = apiCache.releaseDate.split('T')[0];
   }
 
-
-  const onClickAction = `window.location='item/index.html?api_name=${watchHistoryItem.apiName}&api_id=${watchHistoryItem.apiId}'`;
-  return `
-  <tr onclick="${onClickAction}" class=${rowClass}>
+    /*
+    <tr class=${rowClass}>
       <td>${watchHistoryItem.createdAt}</td>
       <td>${watchHistoryItem.apiName}</td>
       <td>${apiCache.title}</td>
       <td>${apiCache.status}</td>
       <td>${apiCache.releaseDate}</td>
     </tr>
-    `;
+    */
+    const tableRow = document.createElement('tr');
+    tableRow.className = rowClass;
+    tableRow.addEventListener('click', function(){ window.open(`item/index.html?api_name=${watchHistoryItem.apiName}&api_id=${watchHistoryItem.apiId}, "_self") });
+
+    const columnValues = [
+        watchHistoryItem.createdAt,
+        watchHistoryItem.apiName,
+        apiCache.title,
+        apiCache.status,
+        apiCache.releaseDate,
+    ]
+    for (let i = 0; i < columnValues.length; i++) {
+        const td = document.createElement('td');
+        td.innerHTML = columnValues[i];
+        tableRow.appendChild(td);
+    }
+
+    document.getElementById('backlog-table-body').appendChild(tableRow);
 }
 
 async function loadMore() {

--- a/docs/includes/js/backlog.js
+++ b/docs/includes/js/backlog.js
@@ -1,6 +1,6 @@
-import {createNavbar} from './common/navbar.js'
-import {MoshanApi} from './api/moshan.js'
-import {isLoggedIn} from './common/auth.js'
+import {createNavbar} from './common/navbar.js';
+import {MoshanApi} from './api/moshan.js';
+import {isLoggedIn} from './common/auth.js';
 
 createNavbar();
 
@@ -72,7 +72,7 @@ function createRow(watchHistoryItem) {
     */
     const tableRow = document.createElement('tr');
     tableRow.className = rowClass;
-    tableRow.addEventListener('click', function(){ window.open(`item/index.html?api_name=${watchHistoryItem.apiName}&api_id=${watchHistoryItem.apiId}`, "_self") });
+    tableRow.addEventListener('click', function(){ window.open(`item/index.html?api_name=${watchHistoryItem.apiName}&api_id=${watchHistoryItem.apiId}`, '_self'); });
 
     const columnValues = [
         watchHistoryItem.createdAt,
@@ -80,7 +80,7 @@ function createRow(watchHistoryItem) {
         apiCache.title,
         apiCache.status,
         apiCache.releaseDate,
-    ]
+    ];
     for (let i = 0; i < columnValues.length; i++) {
         const td = document.createElement('td');
         td.innerHTML = columnValues[i];

--- a/docs/includes/js/backlog.js
+++ b/docs/includes/js/backlog.js
@@ -1,18 +1,17 @@
-/* global MoshanApi, accessToken */
-//const urlParams = new URLSearchParams(window.location.search);
+import {createNavbar} from './common/navbar.js'
+import {MoshanApi} from './api/moshan.js'
+import {isLoggedIn} from './common/auth.js'
+
+createNavbar();
 
 const moshanApi = new MoshanApi();
 
 let currentCursor = null;
 let loadingMore = false;
 
-if (accessToken === null) {
-  document.getElementById('logInAlert').className = 'alert alert-danger';
-} else {
-  document.getElementById('logInAlert').className = 'd-none';
+if (isLoggedIn()) {
+    createTableRows();
 }
-
-createTableRows();
 
 async function createTableRows(cursor='') {
     const response = await moshanApi.getItems('backlogDate', cursor);
@@ -41,7 +40,7 @@ async function createTableRows(cursor='') {
     //   moshanItems[`${responses[i].api_name}_${responses[i].id}`] = responses[i];
     // }
 
-    html = '';
+    let html = '';
     for (let i=0; i< items.length; i++) {
       html += createRow(items[i]);
     }

--- a/docs/includes/js/backlog.js
+++ b/docs/includes/js/backlog.js
@@ -72,7 +72,7 @@ function createRow(watchHistoryItem) {
     */
     const tableRow = document.createElement('tr');
     tableRow.className = rowClass;
-    tableRow.addEventListener('click', function(){ window.open(`item/index.html?api_name=${watchHistoryItem.apiName}&api_id=${watchHistoryItem.apiId}, "_self") });
+    tableRow.addEventListener('click', function(){ window.open(`item/index.html?api_name=${watchHistoryItem.apiName}&api_id=${watchHistoryItem.apiId}`, "_self") });
 
     const columnValues = [
         watchHistoryItem.createdAt,

--- a/docs/includes/js/callback.js
+++ b/docs/includes/js/callback.js
@@ -1,17 +1,25 @@
-/* global axios, redirectBaseUrl, clientId */
+import {redirectBaseUrl, clientId, cognitoDomainName} from './common/config.js'
 
 const urlParams = new URLSearchParams(window.location.search);
 const code = urlParams.get('code');
 const state = urlParams.get('state');
 
+const codeVerifier = localStorage.getItem('pkce_code_verifier');
+const savedState = localStorage.getItem('pkce_state');
+
+localStorage.removeItem('pkce_code_verifier');
+localStorage.removeItem('pkce_state');
+
 if (code === null) {
   document.getElementById('login_status').innerHTML = 'Login <b style=\'color:red\'>failed</b>, forwarding back to home page';
-} else if (state !== localStorage.getItem('pkce_state')) {
+} else if (state !== savedState) {
   document.getElementById('login_status').innerHTML = 'Login <b style=\'color:red\'>failed</b>, forwarding back to home page';
 } else {
   document.getElementById('login_status').innerHTML = 'Login successful, forwarding back to home page';
-  const codeVerifier = localStorage.getItem('pkce_code_verifier');
+  sendPostAuthRequest();
+}
 
+async function sendPostAuthRequest() {
   const postData = new URLSearchParams({
     grant_type: 'authorization_code',
     redirect_uri: `${redirectBaseUrl}/callback.html`,
@@ -19,23 +27,17 @@ if (code === null) {
     client_id: clientId,
     code_verifier: codeVerifier,
   }).toString();
+
   const options = {
     headers: {
       'Content-Type': 'application/x-www-form-urlencoded',
     },
   };
 
-  axios.post(`https://${cognitoDomainName}/oauth2/token`, postData, options)
-    .then(function (response) {
-      const data = response.data;
-      localStorage.setItem('moshan_access_token', data.access_token);
-      localStorage.setItem('moshan_refresh_token', data.refresh_token);
-    })
-    .catch(function (error) {
-      // handle error
-      console.log(error);
-    });
+  const res = await axios.post(`https://${cognitoDomainName}/oauth2/token`, postData, options)
+  const data = res.data;
+  localStorage.setItem('moshan_access_token', data.access_token);
+  localStorage.setItem('moshan_refresh_token', data.refresh_token);
 }
 
-localStorage.removeItem('pkce_code_verifier');
-localStorage.removeItem('pkce_state');
+

--- a/docs/includes/js/callback.js
+++ b/docs/includes/js/callback.js
@@ -1,4 +1,4 @@
-import {redirectBaseUrl, clientId, cognitoDomainName} from './common/config.js'
+import {redirectBaseUrl, clientId, cognitoDomainName} from './common/config.js';
 
 const urlParams = new URLSearchParams(window.location.search);
 const code = urlParams.get('code');
@@ -34,7 +34,7 @@ async function sendPostAuthRequest() {
     },
   };
 
-  const res = await axios.post(`https://${cognitoDomainName}/oauth2/token`, postData, options)
+  const res = await axios.post(`https://${cognitoDomainName}/oauth2/token`, postData, options);
   const data = res.data;
   localStorage.setItem('moshan_access_token', data.access_token);
   localStorage.setItem('moshan_refresh_token', data.refresh_token);

--- a/docs/includes/js/common/auth.js
+++ b/docs/includes/js/common/auth.js
@@ -1,5 +1,5 @@
-import {cognitoDomainName, clientId, redirectBaseUrl} from './config.js'
-import {accessToken, parsedToken} from './token.js'
+import {cognitoDomainName, clientId, redirectBaseUrl} from './config.js';
+import {accessToken} from './token.js';
 
 export function isLoggedIn() {
     return accessToken !== null;

--- a/docs/includes/js/common/auth.js
+++ b/docs/includes/js/common/auth.js
@@ -1,0 +1,66 @@
+import {cognitoDomainName, clientId, redirectBaseUrl} from './config.js'
+import {accessToken, parsedToken} from './token.js'
+
+export function isLoggedIn() {
+    return accessToken !== null;
+}
+
+export function logout () {
+  localStorage.removeItem('moshan_access_token');
+  localStorage.removeItem('moshan_refresh_token');
+  window.location.href = `https://${cognitoDomainName}/logout?logout_uri=${redirectBaseUrl}/index.html&client_id=${clientId}`;
+}
+
+export async function login () {
+  const codeVerifier = generateRandomString();
+
+  const codeChallenge = await codeChallengeFromVerifier(codeVerifier);
+  const state = generateRandomString();
+
+  localStorage.setItem('pkce_code_verifier', codeVerifier);
+  localStorage.setItem('pkce_state', state);
+
+  const authorizeUrl = new URL(`https://${cognitoDomainName}/authorize`);
+
+  authorizeUrl.searchParams.append('code_challenge', codeChallenge);
+  authorizeUrl.searchParams.append('client_id', clientId);
+  authorizeUrl.searchParams.append('response_type', 'code');
+  authorizeUrl.searchParams.append('scope', 'email openid');
+  authorizeUrl.searchParams.append('redirect_uri', `${redirectBaseUrl}/callback.html`);
+  authorizeUrl.searchParams.append('code_challenge_method', 'S256');
+  authorizeUrl.searchParams.append('state', state);
+
+  window.location.href = authorizeUrl.href;
+}
+
+// Helper functions
+
+// See: https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript/1349462
+// dec2hex :: Integer -> String
+// i.e. 0-255 -> '00'-'ff'
+function dec2hex (dec) {
+  return dec < 10
+    ? '0' + String(dec)
+    : dec.toString(16);
+}
+// generateId :: Integer -> String
+function generateRandomString () {
+  const arr = new Uint8Array(40 / 2);
+  window.crypto.getRandomValues(arr);
+  return Array.from(arr, dec2hex).join('');
+}
+
+// Calculate SHA-256 hash from verifier data and base64 encode it
+function sha256 (verifier) {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(verifier);
+  return window.crypto.subtle.digest('SHA-256', data);
+}
+async function codeChallengeFromVerifier (verifier) {
+  const hashed = await sha256(verifier);
+  return base64URLEncode(hashed);
+}
+function base64URLEncode (str) {
+  return btoa(String.fromCharCode.apply(null, new Uint8Array(str)))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+}

--- a/docs/includes/js/common/config.js
+++ b/docs/includes/js/common/config.js
@@ -2,7 +2,7 @@ let internalClientId, internalRedirectBaseUrl;
 
 try {
   // hack for local config
-  const { localClientId, localRedirectBaseUrl } = await import('./configLocal.js');
+  const { localClientId, localRedirectBaseUrl } = import('./configLocal.js');
 
   internalClientId = localClientId;
   internalRedirectBaseUrl = localRedirectBaseUrl;

--- a/docs/includes/js/common/config.js
+++ b/docs/includes/js/common/config.js
@@ -1,0 +1,5 @@
+const cognitoDomainName = 'moshan-fulder-dev.auth.eu-west-1.amazoncognito.com';
+
+let clientId = '1ra91kse5btmpmt3tmran2441a';
+let redirectBaseUrl = 'https://moshan.fulder.dev';
+

--- a/docs/includes/js/common/config.js
+++ b/docs/includes/js/common/config.js
@@ -2,17 +2,13 @@ let internalClientId, internalRedirectBaseUrl;
 
 try {
   // hack for local config
-  if ((new File('./configLocal.js').exists())) {
-    const { localClientId, localRedirectBaseUrl } = await import('./configLocal.js');
+  const { localClientId, localRedirectBaseUrl } = await import('./configLocal.js');
 
-    console.log(localClientId)
-
-    internalClientId = localClientId;
-    internalRedirectBaseUrl = localRedirectBaseUrl;
-  }
+  internalClientId = localClientId;
+  internalRedirectBaseUrl = localRedirectBaseUrl;
 } catch(err) {
-    internalClientId = '1ra91kse5btmpmt3tmran2441a';
-    internalRedirectBaseUrl= 'https://moshan.fulder.dev';
+  internalClientId = '1ra91kse5btmpmt3tmran2441a';
+  internalRedirectBaseUrl= 'https://moshan.fulder.dev';
 }
 
 export const cognitoDomainName = 'moshan-fulder-dev.auth.eu-west-1.amazoncognito.com';

--- a/docs/includes/js/common/config.js
+++ b/docs/includes/js/common/config.js
@@ -1,5 +1,14 @@
-const cognitoDomainName = 'moshan-fulder-dev.auth.eu-west-1.amazoncognito.com';
+import {localClientId, localRedirectBaseUrl} from './configLocal.js'
 
-let clientId = '1ra91kse5btmpmt3tmran2441a';
-let redirectBaseUrl = 'https://moshan.fulder.dev';
+export const cognitoDomainName = 'moshan-fulder-dev.auth.eu-west-1.amazoncognito.com';
 
+export let clientId = '1ra91kse5btmpmt3tmran2441a';
+export let redirectBaseUrl = 'https://moshan.fulder.dev';
+
+if (localClientId !== "") {
+    clientId = localClientId;
+}
+
+if (localRedirectBaseUrl !== "") {
+    redirectBaseUrl = localRedirectBaseUrl;
+}

--- a/docs/includes/js/common/config.js
+++ b/docs/includes/js/common/config.js
@@ -1,14 +1,20 @@
-import {localClientId, localRedirectBaseUrl} from './configLocal.js'
+let internalClientId, internalRedirectBaseUrl;
+
+try {
+  // hack for local config
+  if ((new File('./configLocal.js').exists())) {
+    const { localClientId, localRedirectBaseUrl } = await import('./configLocal.js');
+
+    console.log(localClientId)
+
+    internalClientId = localClientId;
+    internalRedirectBaseUrl = localRedirectBaseUrl;
+  }
+} catch(err) {
+    internalClientId = '1ra91kse5btmpmt3tmran2441a';
+    internalRedirectBaseUrl= 'https://moshan.fulder.dev';
+}
 
 export const cognitoDomainName = 'moshan-fulder-dev.auth.eu-west-1.amazoncognito.com';
-
-export let clientId = '1ra91kse5btmpmt3tmran2441a';
-export let redirectBaseUrl = 'https://moshan.fulder.dev';
-
-if (localClientId !== "") {
-    clientId = localClientId;
-}
-
-if (localRedirectBaseUrl !== "") {
-    redirectBaseUrl = localRedirectBaseUrl;
-}
+export const clientId = internalClientId;
+export const redirectBaseUrl = internalRedirectBaseUrl;

--- a/docs/includes/js/common/configLocal.js_template
+++ b/docs/includes/js/common/configLocal.js_template
@@ -1,0 +1,2 @@
+export const localClientId = '';
+export const localRedirectBaseUrl = '';

--- a/docs/includes/js/common/navbar.js
+++ b/docs/includes/js/common/navbar.js
@@ -1,5 +1,5 @@
-import {login, logout} from './auth.js'
-import {accessToken, parsedToken} from './token.js'
+import {login, logout} from './auth.js';
+import {accessToken, parsedToken} from './token.js';
 
 export async function createNavbar(showAlert = true) {
     await loadHtml();
@@ -23,8 +23,8 @@ export async function createNavbar(showAlert = true) {
 }
 
 async function loadHtml() {
-    const response = await fetch("./../../includes/html/navbar.html")
-    const text = await response.text()
+    const response = await fetch('./../../includes/html/navbar.html');
+    const text = await response.text();
     document.getElementById('navbar').innerHTML = text;
 
     document.getElementById('loginButton').addEventListener('click', login);

--- a/docs/includes/js/common/navbar.js
+++ b/docs/includes/js/common/navbar.js
@@ -1,10 +1,4 @@
-/* global accessToken, parsedToken */
-
-/* exported getDomainName */
-const cognitoDomainName = 'moshan-fulder-dev.auth.eu-west-1.amazoncognito.com';
-const clientId = '1ra91kse5btmpmt3tmran2441a';
-
-
+/* global accessToken, parsedToken, cognitoDomainName, clientId, redirectUrl */
 if (accessToken === null) {
   document.getElementById('loginButton').classList.remove('d-none');
   document.getElementById('profileDropdown').classList.add('d-none');
@@ -20,7 +14,7 @@ if (accessToken === null) {
 function logout () {
   localStorage.removeItem('moshan_access_token');
   localStorage.removeItem('moshan_refresh_token');
-  window.location.href = `https://${cognitoDomainName}/logout?logout_uri=https://${window.location.hostname}/index.html&client_id=${clientId}`;
+  window.location.href = `https://${cognitoDomainName}/logout?logout_uri=${redirectBaseUrl}/index.html&client_id=${clientId}`;
 }
 
 /* exported authorize */
@@ -39,7 +33,7 @@ async function authorize () {
   authorizeUrl.searchParams.append('client_id', clientId);
   authorizeUrl.searchParams.append('response_type', 'code');
   authorizeUrl.searchParams.append('scope', 'email openid');
-  authorizeUrl.searchParams.append('redirect_uri', 'https://' + window.location.hostname + '/callback.html');
+  authorizeUrl.searchParams.append('redirect_uri', `${redirectBaseUrl}/callback.html`);
   authorizeUrl.searchParams.append('code_challenge_method', 'S256');
   authorizeUrl.searchParams.append('state', state);
 

--- a/docs/includes/js/common/navbar.js
+++ b/docs/includes/js/common/navbar.js
@@ -1,73 +1,32 @@
-/* global accessToken, parsedToken, cognitoDomainName, clientId, redirectUrl */
-if (accessToken === null) {
-  document.getElementById('loginButton').classList.remove('d-none');
-  document.getElementById('profileDropdown').classList.add('d-none');
-} else {
-  document.getElementById('loginButton').classList.add('d-none');
-  document.getElementById('profileDropdown').classList.remove('d-none');
+import {login, logout} from './auth.js'
+import {accessToken, parsedToken} from './token.js'
 
-  const profileDropDown = document.getElementById('profileDropdown');
-  profileDropDown.innerHTML = parsedToken.username;
+export async function createNavbar(showAlert = true) {
+    await loadHtml();
+
+    if (accessToken === null) {
+      document.getElementById('loginButton').classList.remove('d-none');
+      document.getElementById('profileDropdown').classList.add('d-none');
+      if (showAlert) {
+        document.getElementById('logInAlert').className = 'alert alert-danger';
+      }
+    } else {
+      document.getElementById('loginButton').classList.add('d-none');
+      document.getElementById('profileDropdown').classList.remove('d-none');
+      if (!showAlert) {
+        document.getElementById('logInAlert').className = 'd-none';
+      }
+
+      const profileDropDown = document.getElementById('profileDropdown');
+      profileDropDown.innerHTML = parsedToken.username;
+    }
 }
 
-/* exported logout */
-function logout () {
-  localStorage.removeItem('moshan_access_token');
-  localStorage.removeItem('moshan_refresh_token');
-  window.location.href = `https://${cognitoDomainName}/logout?logout_uri=${redirectBaseUrl}/index.html&client_id=${clientId}`;
-}
+async function loadHtml() {
+    const response = await fetch("./../../includes/html/navbar.html")
+    const text = await response.text()
+    document.getElementById('navbar').innerHTML = text;
 
-/* exported authorize */
-async function authorize () {
-  const codeVerifier = generateRandomString();
-
-  const codeChallenge = await codeChallengeFromVerifier(codeVerifier);
-  const state = generateRandomString();
-
-  localStorage.setItem('pkce_code_verifier', codeVerifier);
-  localStorage.setItem('pkce_state', state);
-
-  const authorizeUrl = new URL(`https://${cognitoDomainName}/authorize`);
-
-  authorizeUrl.searchParams.append('code_challenge', codeChallenge);
-  authorizeUrl.searchParams.append('client_id', clientId);
-  authorizeUrl.searchParams.append('response_type', 'code');
-  authorizeUrl.searchParams.append('scope', 'email openid');
-  authorizeUrl.searchParams.append('redirect_uri', `${redirectBaseUrl}/callback.html`);
-  authorizeUrl.searchParams.append('code_challenge_method', 'S256');
-  authorizeUrl.searchParams.append('state', state);
-
-  window.location.href = authorizeUrl.href;
-}
-
-// Helper functions
-
-// See: https://stackoverflow.com/questions/1349404/generate-random-string-characters-in-javascript/1349462
-// dec2hex :: Integer -> String
-// i.e. 0-255 -> '00'-'ff'
-function dec2hex (dec) {
-  return dec < 10
-    ? '0' + String(dec)
-    : dec.toString(16);
-}
-// generateId :: Integer -> String
-function generateRandomString () {
-  const arr = new Uint8Array(40 / 2);
-  window.crypto.getRandomValues(arr);
-  return Array.from(arr, dec2hex).join('');
-}
-
-// Calculate SHA-256 hash from verifier data and base64 encode it
-function sha256 (verifier) {
-  const encoder = new TextEncoder();
-  const data = encoder.encode(verifier);
-  return window.crypto.subtle.digest('SHA-256', data);
-}
-async function codeChallengeFromVerifier (verifier) {
-  const hashed = await sha256(verifier);
-  return base64URLEncode(hashed);
-}
-function base64URLEncode (str) {
-  return btoa(String.fromCharCode.apply(null, new Uint8Array(str)))
-    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '');
+    document.getElementById('loginButton').addEventListener('click', login);
+    document.getElementById('logoutButton').addEventListener('click', logout);
 }

--- a/docs/includes/js/common/token.js
+++ b/docs/includes/js/common/token.js
@@ -1,13 +1,13 @@
-/* global axios */
-/* exported parseJwt */
-let accessToken = localStorage.getItem('moshan_access_token');
-let parsedToken = null;
+import {clientId, cognitoDomainName} from './config.js'
+
+export let accessToken = localStorage.getItem('moshan_access_token');
+export let parsedToken = null;
 
 if (accessToken !== null) {
   parsedToken = parseJwt(accessToken);
 }
 
-function parseJwt (token) {
+export function parseJwt (token) {
   try {
     return JSON.parse(atob(token.split('.')[1]));
   } catch (e) {
@@ -15,11 +15,10 @@ function parseJwt (token) {
   }
 }
 
-/* exported checkToken */
-async function checkToken () {
+export async function checkToken () {
   const currentTimeStamp = Math.floor(Date.now() / 1000);
 
-  if (parsedToken.exp < currentTimeStamp) {
+  if (parsedToken !== null && parsedToken.exp < currentTimeStamp) {
     accessToken = await refreshToken();
     parsedToken = parseJwt(accessToken);
   }

--- a/docs/includes/js/common/token.js
+++ b/docs/includes/js/common/token.js
@@ -1,4 +1,4 @@
-import {clientId, cognitoDomainName} from './config.js'
+import {clientId, cognitoDomainName} from './config.js';
 
 export let accessToken = localStorage.getItem('moshan_access_token');
 export let parsedToken = null;

--- a/docs/includes/js/episode.js
+++ b/docs/includes/js/episode.js
@@ -5,6 +5,11 @@ import {isLoggedIn} from './common/auth.js'
 
 createNavbar();
 
+document.getElementById('addButton').addEventListener('click', addEpisode);
+document.getElementById('removeButton').addEventListener('click', removeEpisode);
+document.getElementById('setDateButton').addEventListener('click', setCurrentWatchDate);
+document.getElementById('removeDateButton').addEventListener('click', removeWatchDate);
+
 const urlParams = new URLSearchParams(window.location.search);
 const qParams = new QueryParams(urlParams);
 
@@ -88,9 +93,9 @@ function createEpisodePage (moshanEpisode, watchHistoryEpisode) {
   }
 
   if (episodeAdded) {
-    document.getElementById('remove_button').classList.remove('d-none');
+    document.getElementById('removeButton').classList.remove('d-none');
   } else {
-    document.getElementById('add_button').classList.remove('d-none');
+    document.getElementById('addButton').classList.remove('d-none');
   }
 
   document.getElementById('episode').classList.remove('d-none');
@@ -120,7 +125,6 @@ async function onCalendarClose (selectedDates, dateStr) {
   await patchWatchDate(date);
 }
 
-/* exported setCurrentWatchDate */
 async function setCurrentWatchDate() {
   const dateNow = new Date();
 
@@ -141,7 +145,6 @@ async function patchWatchDate(date) {
   await moshanApi.updateEpisode(qParams, datesWatched);
 }
 
-/* exported removeWatchDate */
 async function removeWatchDate() {
   if (datesWatched === undefined || datesWatched.length == 0) {
     return;
@@ -159,17 +162,19 @@ async function removeWatchDate() {
   await moshanApi.updateEpisode(qParams, datesWatched);
 }
 
-/* exported addEpisode */
-async function addEpisode () {
+async function addEpisode (evt) {
   const addEpisodeRes = await moshanApi.addEpisode(qParams);
   qParams.episode_id = addEpisodeRes.data.id;
-  document.getElementById('add_button').classList.add('d-none');
-  document.getElementById('remove_button').classList.remove('d-none');
+  document.getElementById('addButton').classList.add('d-none');
+  document.getElementById('removeButton').classList.remove('d-none');
+
+  evt.target.blur();
 }
 
-/* exported removeEpisode */
-async function removeEpisode () {
+async function removeEpisode (evt) {
   await moshanApi.removeEpisode(qParams);
-  document.getElementById('add_button').classList.remove('d-none');
-  document.getElementById('remove_button').classList.add('d-none');
+  document.getElementById('addButton').classList.remove('d-none');
+  document.getElementById('removeButton').classList.add('d-none');
+
+  evt.target.blur();
 }

--- a/docs/includes/js/episode.js
+++ b/docs/includes/js/episode.js
@@ -1,5 +1,10 @@
-/* global flatpickr, getApiByName */
-/* global MoshanApi */
+import {createNavbar} from './common/navbar.js'
+import {getApiByName} from './api/common.js'
+import {MoshanApi} from './api/moshan.js'
+import {isLoggedIn} from './common/auth.js'
+
+createNavbar();
+
 const urlParams = new URLSearchParams(window.location.search);
 const qParams = new QueryParams(urlParams);
 
@@ -9,7 +14,9 @@ const api = getApiByName(qParams.api_name);
 let datesWatched;
 let calendarInstance;
 
-getEpisode();
+if (isLoggedIn()) {
+  getEpisode();
+}
 
 function QueryParams(urlParams) {
   this.collection = urlParams.get('collection');

--- a/docs/includes/js/episode.js
+++ b/docs/includes/js/episode.js
@@ -1,7 +1,7 @@
-import {createNavbar} from './common/navbar.js'
-import {getApiByName} from './api/common.js'
-import {MoshanApi} from './api/moshan.js'
-import {isLoggedIn} from './common/auth.js'
+import {createNavbar} from './common/navbar.js';
+import {getApiByName} from './api/common.js';
+import {MoshanApi} from './api/moshan.js';
+import {isLoggedIn} from './common/auth.js';
 
 createNavbar();
 

--- a/docs/includes/js/history.js
+++ b/docs/includes/js/history.js
@@ -1,18 +1,17 @@
-/* global MoshanApi, accessToken */
-// const urlParams = new URLSearchParams(window.location.search);
-// const qParams = new QueryParams(urlParams);
+import {createNavbar} from './common/navbar.js';
+import {MoshanApi} from './api/moshan.js';
+import {isLoggedIn} from './common/auth.js';
+
+createNavbar();
+
 const moshanApi = new MoshanApi();
 
 let currentCursor = null;
 let loadingMore = false;
 
-if (accessToken === null) {
-  document.getElementById('logInAlert').className = 'alert alert-danger';
-} else {
-  document.getElementById('logInAlert').className = 'd-none';
+if (isLoggedIn()) {
+    createHistory();
 }
-
-createHistory();
 
 async function createHistory(cursor='') {
   const response = await moshanApi.getItems('latestWatchDate', cursor);

--- a/docs/includes/js/index.js
+++ b/docs/includes/js/index.js
@@ -1,0 +1,3 @@
+import {createNavbar} from './common/navbar.js'
+
+createNavbar(false);

--- a/docs/includes/js/index.js
+++ b/docs/includes/js/index.js
@@ -1,3 +1,3 @@
-import {createNavbar} from './common/navbar.js'
+import {createNavbar} from './common/navbar.js';
 
 createNavbar(false);

--- a/docs/includes/js/item.js
+++ b/docs/includes/js/item.js
@@ -1,4 +1,10 @@
-/* global MoshanApi, getApiByName */
+import {getApiByName} from './api/common.js'
+import {MoshanApi} from './api/moshan.js'
+import {createNavbar} from './common/navbar.js'
+import {isLoggedIn} from './common/auth.js'
+
+createNavbar();
+
 const urlParams = new URLSearchParams(window.location.search);
 const qParams = new QueryParams(urlParams);
 
@@ -11,8 +17,11 @@ let watchHistoryEpisodeIDs = [];
 let totalPages = 0;
 let calendarInstances = {};
 let savedPatchData;
+let currentPatchData;
 
-getItemByApiId();
+if (isLoggedIn()) {
+  getItemByApiId();
+}
 
 window.onbeforeunload = function(){
   console.debug(savedPatchData);
@@ -49,22 +58,22 @@ function QueryParams(urlParams) {
 }
 
 async function getItemByApiId() {
-  let watchHistoryItem = null;
+  let item = null;
   try {
-    const watchHistoryItemRes = await moshanApi.getItem(qParams);
-    console.debug(watchHistoryItemRes);
-    watchHistoryItem = watchHistoryItemRes.data;
+    item = await moshanApi.getItem(qParams).data;
   } catch(error) {
     if (!('response' in error && error.response.status == 404)) {
       console.log(error);
     }
   }
 
-  moshanItem = await api.getItemById(qParams);
+  if (item === null) {
+    item = await api.getItemById(qParams);
+  }
 
-  createItem(moshanItem, watchHistoryItem);
+  /*createItem(item);
 
-  if (moshanItem.has_episodes) {
+  if (item.hasEpisodes) {
     const moshanEpisodes = await api.getEpisodes(qParams);
     const watchHistoryEpisodes = await moshanApi.getEpisodes(qParams);
     for (let i=0; i < watchHistoryEpisodes.data.episodes.length; i++) {
@@ -89,7 +98,7 @@ async function getItemByApiId() {
     }
 
     createEpisodesList(moshanEpisodes);
-  }
+  }*/
 }
 
 function createItem (moshanItem, watchHistoryItem) {
@@ -193,7 +202,7 @@ function getPatchData() {
     let watchedDates = [];
     const calendarDivs = document.getElementById('watched-dates').getElementsByTagName('div');
 
-    for( i=0; i< calendarDivs.length; i++ ) {
+    for(let i=0; i< calendarDivs.length; i++ ) {
      const childDiv = calendarDivs[i];
      const calendarNbr = childDiv.dataset.calendarNumber;
 

--- a/docs/includes/js/item.js
+++ b/docs/includes/js/item.js
@@ -60,7 +60,7 @@ function QueryParams(urlParams) {
 async function getItemByApiId() {
   let item = null;
   try {
-    item = await moshanApi.getItem(qParams).data;
+    item = await moshanApi.getItem(qParams);
   } catch(error) {
     if (!('response' in error && error.response.status == 404)) {
       console.log(error);
@@ -71,9 +71,9 @@ async function getItemByApiId() {
     item = await api.getItemById(qParams);
   }
 
-  /*createItem(item);
+  createItem(item);
 
-  if (item.hasEpisodes) {
+  /*if (item.hasEpisodes) {
     const moshanEpisodes = await api.getEpisodes(qParams);
     const watchHistoryEpisodes = await moshanApi.getEpisodes(qParams);
     for (let i=0; i < watchHistoryEpisodes.data.episodes.length; i++) {
@@ -101,37 +101,38 @@ async function getItemByApiId() {
   }*/
 }
 
-function createItem (moshanItem, watchHistoryItem) {
-  const itemAdded = watchHistoryItem !== null;
+function createItem (item) {
+  const itemAdded = item.apiName === "moshan";
   console.debug(`Item added: ${itemAdded}`);
-  console.debug(moshanItem);
+  console.debug(item);
+
 
   let datesWatched = [];
-  if (itemAdded && 'datesWatched' in watchHistoryItem && watchHistoryItem['datesWatched'].length > 0) {
-    datesWatched = watchHistoryItem['datesWatched'];
+  if (itemAdded && 'datesWatched' in item.review && item.review.datesWatched.length > 0) {
+    datesWatched = item.review.datesWatched;
   }
 
-  if (itemAdded && 'overview' in watchHistoryItem) {
-      document.getElementById('overview').value = watchHistoryItem.overview;
+  if (item.review.overview !== undefined) {
+      document.getElementById('overview').value = item.review.overview;
   }
-  if (itemAdded && 'review' in watchHistoryItem) {
-      document.getElementById('review').value = watchHistoryItem.review;
+  if (item.review.review !== undefined) {
+      document.getElementById('review').value = item.review.review;
   }
-  if (itemAdded && 'status' in watchHistoryItem) {
-      document.getElementById('user-status').value = watchHistoryItem.status;
+  if (item.review.status !== undefined) {
+      document.getElementById('user-status').value = item.review.status;
   }
-  if (itemAdded && 'rating' in watchHistoryItem) {
-      document.getElementById('user-rating').value = watchHistoryItem.rating;
+  if (item.review.rating) {
+      document.getElementById('user-rating').value = item.review.rating;
   }
-  if (itemAdded && 'createdAt' in watchHistoryItem) {
-      document.getElementById('user_added_date').innerHTML = watchHistoryItem.createdAt;
+  if (item.review.createdAt) {
+      document.getElementById('user_added_date').innerHTML = item.review.createdAt;
   }
 
-  document.getElementById('poster').src = moshanItem.poster;
-  document.getElementById('title').innerHTML = moshanItem.title;
-  document.getElementById('start-date').innerHTML = moshanItem.start_date;
-  document.getElementById('status').innerHTML = moshanItem.status;
-  document.getElementById('synopsis').innerHTML = moshanItem.synopsis;
+  document.getElementById('poster').src = item.imageUrl;
+  document.getElementById('title').innerHTML = item.title;
+  document.getElementById('start-date').innerHTML = item.releaseDate;
+  document.getElementById('status').innerHTML = item.status;
+  //document.getElementById('synopsis').innerHTML = item.synopsis;
   document.getElementById('watched_amount').innerHTML = datesWatched.length;
 
   // TODO: store links in api and loop through them creating the links dynamically
@@ -149,7 +150,7 @@ function createItem (moshanItem, watchHistoryItem) {
     document.getElementById('add_button').classList.remove('d-none');
   }
 
-  if (!moshanItem.has_episodes) {
+  if (!item.hasEpisodes) {
     if (datesWatched.length === 0) {
       createOneCalendar();
     }

--- a/docs/includes/js/item.js
+++ b/docs/includes/js/item.js
@@ -1,7 +1,7 @@
-import {getApiByName} from './api/common.js'
-import {MoshanApi} from './api/moshan.js'
-import {createNavbar} from './common/navbar.js'
-import {isLoggedIn} from './common/auth.js'
+import {getApiByName} from './api/common.js';
+import {MoshanApi} from './api/moshan.js';
+import {createNavbar} from './common/navbar.js';
+import {isLoggedIn} from './common/auth.js';
 
 createNavbar();
 
@@ -107,7 +107,7 @@ async function getItemByApiId() {
 }
 
 function createItem (item) {
-  const itemAdded = item.apiName === "moshan";
+  const itemAdded = item.apiName === 'moshan';
   console.debug(`Item added: ${itemAdded}`);
   console.debug(item);
 
@@ -204,8 +204,8 @@ function createOneCalendar(calDate=null) {
 
   console.debug(calendarInstances);
 
-  document.getElementById(`setDateButton${calendarId}`).addEventListener('click', function(){setCurrentWatchDate(this, i)});
-  document.getElementById(`removeDateButton${calendarId}`).addEventListener('click', function(){removeWatchDate(this, i)});
+  document.getElementById(`setDateButton${calendarId}`).addEventListener('click', function(){setCurrentWatchDate(this, i);});
+  document.getElementById(`removeDateButton${calendarId}`).addEventListener('click', function(){removeWatchDate(this, i);});
 }
 
 function getPatchData() {
@@ -319,18 +319,18 @@ function createEpisodesList (apiEpisodes) {
     */
     const tableRow = document.createElement('tr');
     tableRow.className = rowClass;
-    tableRow.addEventListener('click', function(){ window.open(onClickAction, "_self") });
+    tableRow.addEventListener('click', function(){ window.open(onClickAction, '_self'); });
 
     const epNumberRow = document.createElement('td');
-    epNumberRow.className = "small";
+    epNumberRow.className = 'small';
     epNumberRow.innerHTML = moshanEpisode.number;
     tableRow.appendChild(epNumberRow);
     const epTitleRow = document.createElement('td');
-    epTitleRow.className = "text-truncate small";
+    epTitleRow.className = 'text-truncate small';
     epTitleRow.innerHTML = moshanEpisode.title;
     tableRow.appendChild(epTitleRow);
     const epAirDate = document.createElement('td');
-    epAirDate.className = "small";
+    epAirDate.className = 'small';
     epAirDate.innerHTML = moshanEpisode.air_date;
     tableRow.appendChild(epAirDate);
     document.getElementById('episodeTableBody').appendChild(tableRow);
@@ -349,10 +349,10 @@ function createEpisodesList (apiEpisodes) {
     const previousLi = document.createElement('li');
     previousLi.className='page-item';
     const previousA = document.createElement('a');
-    previousA.className = 'page-link'
+    previousA.className = 'page-link';
     previousA.href = 'javascript:void(0)';
-    previousA.innerHTML = "Previous"
-    previousA.addEventListener('click', loadPreviousEpisodes)
+    previousA.innerHTML = 'Previous';
+    previousA.addEventListener('click', loadPreviousEpisodes);
     previousLi.appendChild(previousA);
     document.getElementById('episodesPages').appendChild(previousLi);
 
@@ -366,10 +366,10 @@ function createEpisodesList (apiEpisodes) {
       }
 
       const a = document.createElement('a');
-      a.className = 'page-link'
+      a.className = 'page-link';
       a.href = 'javascript:void(0)';
       a.innerHTML = i;
-      a.addEventListener('click', function(){loadEpisodes(i, a)})
+      a.addEventListener('click', function(){loadEpisodes(i, a);});
       li.appendChild(a);
       document.getElementById('episodesPages').appendChild(li);
     }
@@ -377,10 +377,10 @@ function createEpisodesList (apiEpisodes) {
     const nextLi = document.createElement('li');
     nextLi.className='page-item';
     const nextA = document.createElement('a');
-    nextA.className = 'page-link'
+    nextA.className = 'page-link';
     nextA.href = 'javascript:void(0)';
-    nextA.innerHTML = "Next"
-    nextA.addEventListener('click', loadNextEpisodes)
+    nextA.innerHTML = 'Next';
+    nextA.addEventListener('click', loadNextEpisodes);
     nextLi.appendChild(nextA);
     document.getElementById('episodesPages').appendChild(nextLi);
   }
@@ -433,9 +433,9 @@ function setCurrentWatchDate(button, calendarIndex) {
 }
 
 function removeWatchDate(button, calendarIndex) {
-    console.log(calendarIndex)
-    console.log(calendarInstances[calendarIndex])
-    console.log(calendarInstances)
+    console.log(calendarIndex);
+    console.log(calendarInstances[calendarIndex]);
+    console.log(calendarInstances);
   const previousDates = calendarInstances[calendarIndex].selectedDates;
 
   const calendarAmount = Object.keys(calendarInstances).length;

--- a/docs/includes/js/oauth_callback.js
+++ b/docs/includes/js/oauth_callback.js
@@ -1,4 +1,4 @@
-/* global axios */
+/* global axios, redirectBaseUrl, clientId */
 
 const urlParams = new URLSearchParams(window.location.search);
 const code = urlParams.get('code');
@@ -14,7 +14,7 @@ if (code === null) {
 
   const postData = new URLSearchParams({
     grant_type: 'authorization_code',
-    redirect_uri: 'https://' + window.location.hostname + '/callback.html',
+    redirect_uri: `${redirectBaseUrl}/callback.html`,
     code: code,
     client_id: clientId,
     code_verifier: codeVerifier,

--- a/docs/includes/js/results.js
+++ b/docs/includes/js/results.js
@@ -1,3 +1,9 @@
+import {createNavbar} from './common/navbar.js'
+import {getApiByName} from './api/common.js'
+import {isLoggedIn} from './common/auth.js'
+
+createNavbar();
+
 /* global accessToken */
 const urlParams = new URLSearchParams(window.location.search);
 const qParams = new QueryParams(urlParams);
@@ -11,16 +17,13 @@ const animeApi = getApiByName(animeApiName);
 const showApi = getApiByName(showApiName);
 const movieApi = getApiByName(movieApiName);
 
-if (accessToken === null) {
-  document.getElementById('logInAlert').className = 'alert alert-danger';
-} else {
-  document.getElementById('logInAlert').className = 'd-none';
+if (isLoggedIn()) {
   document.getElementById('animeResults').innerHTML = '<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>';
   document.getElementById('showResults').innerHTML = '<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>';
   document.getElementById('movieResults').innerHTML = '<div class="spinner-border" role="status"><span class="sr-only">Loading...</span></div>';
-}
 
-getResults();
+  getResults();
+}
 
 function QueryParams(urlParams) {
   this.search = urlParams.get('search');
@@ -45,7 +48,7 @@ function createResults(moshanItems, apiName) {
     resultHTML += `
       <div class="col-4 col-md-2 poster">
         <a href="/item/index.html?collection=${moshanItems.collection_name}&api_name=${apiName}&api_id=${moshanItem.id}">
-          <img class="img-fluid" src=${moshanItem.poster} />
+          <img class="img-fluid" src=${moshanItem.imageUrl} />
           <p class="text-truncate small">${moshanItem.title}</p>
         </a>
       </div>

--- a/docs/includes/js/results.js
+++ b/docs/includes/js/results.js
@@ -1,10 +1,9 @@
-import {createNavbar} from './common/navbar.js'
-import {getApiByName} from './api/common.js'
-import {isLoggedIn} from './common/auth.js'
+import {createNavbar} from './common/navbar.js';
+import {getApiByName} from './api/common.js';
+import {isLoggedIn} from './common/auth.js';
 
 createNavbar();
 
-/* global accessToken */
 const urlParams = new URLSearchParams(window.location.search);
 const qParams = new QueryParams(urlParams);
 

--- a/docs/includes/js/unwatched.js
+++ b/docs/includes/js/unwatched.js
@@ -1,20 +1,15 @@
-/* global MoshanApi, accessToken */
-// const urlParams = new URLSearchParams(window.location.search);
-// const qParams = new QueryParams(urlParams);
+import {createNavbar} from './common/navbar.js'
+import {MoshanApi} from './api/moshan.js'
+import {isLoggedIn} from './common/auth.js'
+
+createNavbar();
 
 const moshanApi = new MoshanApi();
 
-if (accessToken === null) {
-  document.getElementById('logInAlert').className = 'alert alert-danger';
-} else {
-  document.getElementById('logInAlert').className = 'd-none';
+
+if (isLoggedIn()) {
+    createUnwatchedItems();
 }
-
-createUnwatchedItems();
-
-// function QueryParams(urlParams) {
-//
-// }
 
 async function createUnwatchedItems(cursor='') {
   const response = await moshanApi.getItems('epProgress', cursor);

--- a/docs/includes/js/unwatched.js
+++ b/docs/includes/js/unwatched.js
@@ -6,7 +6,6 @@ createNavbar();
 
 const moshanApi = new MoshanApi();
 
-
 if (isLoggedIn()) {
     createUnwatchedItems();
 }

--- a/docs/includes/js/unwatched.js
+++ b/docs/includes/js/unwatched.js
@@ -1,6 +1,6 @@
-import {createNavbar} from './common/navbar.js'
-import {MoshanApi} from './api/moshan.js'
-import {isLoggedIn} from './common/auth.js'
+import {createNavbar} from './common/navbar.js';
+import {MoshanApi} from './api/moshan.js';
+import {isLoggedIn} from './common/auth.js';
 
 createNavbar();
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -91,6 +91,7 @@
 </footer>
 
 <!-- Moshan scripts -->
+<script src="/includes/js/common/config.js"></script>
 <script src="/includes/js/common/navbar.js"></script>
 
 <!-- Boostrap JavaScript -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -18,67 +18,15 @@
     <!-- Moshan CSS -->
     <link rel="stylesheet" href="/includes/css/style.css">
 
-    <!-- Moshan scripts -->
-    <script src="/includes/js/common/token.js"></script>
-
     <!-- Font Awesome Icons -->
     <script src="https://kit.fontawesome.com/f013262c1a.js" crossorigin="anonymous"></script>
 
     <title>Moshan - Movies/Shows/Anime in one place</title>
 </head>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
-
-    <a class="navbar-brand" href="/index.html">
-      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
-            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarToggler">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/index.html">Moshan</a>
-            </li>
-        </ul>
-
-        <ul class="navbar-nav">
-            <li class="nav-item mr-3">
-                <form class="form-inline" action="/results.html">
-                    <div class="input-group">
-                        <input type="text" class="form-control" placeholder="Search" name="search">
-                        <div class="input-group-prepend">
-                            <button class="btn btn-success" type="submit">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </li>
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"></a>
-              <ul class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
-                <li><a class="dropdown-item" href="/unwatched.html">Unwatched</a></li>
-                <li><a class="dropdown-item" href="/backlog.html">Backlog</a></li>
-                <li><a class="dropdown-item" href="/history.html">History</a></li>
-                <li><hr class="dropdown-divider"></li>
-                <li><a class="dropdown-item text-danger" onclick="logout()" href="#">Logout</a></li>
-              </ul>
-            </li>
-        </ul>
-        <button id="loginButton" onclick="authorize()" class="btn btn-outline-success nav-item" type="submit">
-            <i class="fas fa-sign-in-alt"></i>
-            Login
-        </button>
-    </div>
-</nav>
+<div id="navbar"></div>
 
 <body>
-<div class="alert alert-danger" role="alert">
-    Note! Moshan is currently in closed alpha state. Registration will be available shortly.
-</div>
 <div class="bg-light p-4">
     <h1 class="display-4">Moshan</h1>
     <p class="lead">Movies, Shows and Anime in one place</p>
@@ -90,9 +38,7 @@
     <p>© Moshan 2021</p>
 </footer>
 
-<!-- Moshan scripts -->
-<script src="/includes/js/common/config.js"></script>
-<script src="/includes/js/common/navbar.js"></script>
+<script type="module" src="/includes/js/index.js"></script>
 
 <!-- Boostrap JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/docs/item/index.html
+++ b/docs/item/index.html
@@ -195,6 +195,7 @@
 </footer>
 
 <!-- Moshan scripts -->
+<script src="/includes/js/common/config.js"></script>
 <script src="/includes/js/common/navbar.js"></script>
 
 <script src="/includes/js/api/moshan.js"></script>

--- a/docs/item/index.html
+++ b/docs/item/index.html
@@ -55,9 +55,9 @@
 
       <div class="col-md-7 col-12 mt-1 row">
           <div>
-            <button id="save_info" class="btn btn-success" onclick="saveItem(this)"><i class="fa fa-save"></i> Save</button>
-            <button id="add_button" class="btn btn-success d-none" onclick="addItem(this)"><i class="fa fa-plus"></i> Add</button>
-            <button id="remove_button" class="btn btn-danger d-none" onclick="removeItem(this)"><i class="fa fa-minus"></i> Remove</button>
+            <button id="saveItem" class="btn btn-success"><i class="fa fa-save"></i> Save</button>
+            <button id="addButton" class="btn btn-success d-none"><i class="fa fa-plus"></i> Add</button>
+            <button id="removeButton" class="btn btn-danger d-none"><i class="fa fa-minus"></i> Remove</button>
           </div>
 
           <div class="col-md-6 col-11 pe-0">

--- a/docs/item/index.html
+++ b/docs/item/index.html
@@ -67,7 +67,7 @@
           </div>
 
           <div class="col-1 ps-1 pt-1">
-            <button id="new-calendar-button" class="btn btn-success rounded-circle" type="button" onclick="addCalendar(this)"><i class="fas fa-plus"></i></button>
+            <button id="newCalendarButton" class="btn btn-success rounded-circle" type="button"><i class="fas fa-plus"></i></button>
           </div>
 
 

--- a/docs/item/index.html
+++ b/docs/item/index.html
@@ -19,7 +19,7 @@
     <link rel="stylesheet" href="/includes/css/style.css">
 
     <!-- Moshan scripts -->
-    <script src="/includes/js/common/token.js"></script>
+    <script type="module" src="/includes/js/common/token.js"></script>
 
     <!-- Font Awesome Icons -->
     <script src="https://kit.fontawesome.com/f013262c1a.js" crossorigin="anonymous"></script>
@@ -31,53 +31,7 @@
     <title id="headTitle"></title>
 </head>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
-    <a class="navbar-brand" href="/index.html">
-      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
-            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarToggler">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/index.html">Home</a>
-            </li>
-        </ul>
-
-        <ul class="navbar-nav">
-            <li class="nav-item mr-3">
-                <form class="form-inline" action="/results.html">
-                    <div class="input-group">
-                        <input type="text" class="form-control" placeholder="Search" name="search">
-                        <div class="input-group-prepend">
-                            <button class="btn btn-success" type="submit">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </li>
-
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"></a>
-              <ul class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
-                <li><a class="dropdown-item" href="/unwatched.html">Unwatched</a></li>
-                <li><a class="dropdown-item" href="/backlog.html">Backlog</a></li>
-                <li><a class="dropdown-item" href="/history.html">History</a></li>
-                <li><hr class="dropdown-divider"></li>
-                <li><a class="dropdown-item text-danger" onclick="logout()" href="#">Logout</a></li>
-              </ul>
-            </li>
-        </ul>
-        <button id="loginButton" onclick="authorize()" class="btn btn-outline-success nav-item" type="submit">
-            <i class="fas fa-sign-in-alt"></i>
-            Login
-        </button>
-    </div>
-</nav>
+<div id="navbar"></div>
 
 <body>
 
@@ -195,19 +149,7 @@
 </footer>
 
 <!-- Moshan scripts -->
-<script src="/includes/js/common/config.js"></script>
-<script src="/includes/js/common/navbar.js"></script>
-
-<script src="/includes/js/api/moshan.js"></script>
-
-<script src="/includes/js/api/mal.js"></script>
-<script src="/includes/js/api/tvmaze.js"></script>
-<script src="/includes/js/api/tmdb.js"></script>
-
-<script src="/includes/js/api/common.js"></script>
-
-<script src="/includes/js/item.js"></script>
-
+<script type="module" src="/includes/js/item.js"></script>
 
 <!-- Boostrap JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -13,7 +13,8 @@
         "eslint-config-standard": "^17.0.0",
         "eslint-plugin-import": "^2.22.1",
         "eslint-plugin-node": "^11.1.0",
-        "eslint-plugin-promise": "^6.0.0"
+        "eslint-plugin-promise": "^6.0.0",
+        "http-server": "^14.1.1"
       }
     },
     "node_modules/@eslint/eslintrc": {
@@ -151,11 +152,32 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "node_modules/basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "dependencies": {
+        "safe-buffer": "5.1.2"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -216,9 +238,9 @@
       }
     },
     "node_modules/chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -226,6 +248,9 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "node_modules/chalk/node_modules/ansi-styles": {
@@ -284,6 +309,15 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
+    },
+    "node_modules/corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4.0"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -864,6 +898,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -924,6 +964,26 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
       "dev": true
+    },
+    "node_modules/follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
     },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
@@ -1078,6 +1138,80 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "dependencies": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "dependencies": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      },
+      "bin": {
+        "http-server": "bin/http-server"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/ignore": {
@@ -1397,6 +1531,12 @@
         "node": ">=4"
       }
     },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -1416,6 +1556,18 @@
         "node": ">=10"
       }
     },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true,
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -1433,6 +1585,18 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      }
     },
     "node_modules/ms": {
       "version": "2.1.2",
@@ -1506,6 +1670,15 @@
       "dev": true,
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "bin": {
+        "opener": "bin/opener-bin.js"
       }
     },
     "node_modules/optionator": {
@@ -1603,6 +1776,29 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "node_modules/portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "dev": true,
+      "dependencies": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "engines": {
+        "node": ">= 0.12.0"
+      }
+    },
+    "node_modules/portfinder/node_modules/debug": {
+      "version": "3.2.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.1"
+      }
+    },
     "node_modules/prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -1621,6 +1817,21 @@
         "node": ">=6"
       }
     },
+    "node_modules/qs": {
+      "version": "6.10.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.5.tgz",
+      "integrity": "sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==",
+      "dev": true,
+      "dependencies": {
+        "side-channel": "^1.0.4"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
@@ -1632,6 +1843,12 @@
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
       }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true
     },
     "node_modules/resolve": {
       "version": "1.22.0",
@@ -1673,6 +1890,24 @@
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
       }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
     },
     "node_modules/semver": {
       "version": "6.3.0",
@@ -1846,6 +2081,18 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "dependencies": {
+        "qs": "^6.4.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -1855,11 +2102,29 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
+    },
     "node_modules/v8-compile-cache": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -2018,11 +2283,29 @@
         "es-shim-unscopables": "^1.0.0"
       }
     },
+    "async": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.4.tgz",
+      "integrity": "sha512-mzo5dfJYwAn29PeiJ0zvwTo04zj8HDJj0Mn8TD7sno7q12prdbnasKJHhkm2c1LgrhlJ0teaea8860oxi51mGA==",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.14"
+      }
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
+    },
+    "basic-auth": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/basic-auth/-/basic-auth-2.0.1.tgz",
+      "integrity": "sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.2"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
@@ -2073,9 +2356,9 @@
       "dev": true
     },
     "chalk": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
-      "integrity": "sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
       "dev": true,
       "requires": {
         "ansi-styles": "^4.1.0",
@@ -2127,6 +2410,12 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "corser": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/corser/-/corser-2.0.1.tgz",
+      "integrity": "sha512-utCYNzRSQIZNPIcGZdQc92UVJYAhtGAteCFg0yRaFm8f0P+CPtyGyHXJcGXnffjCybUCEx3FQ2G7U3/o9eIkVQ==",
       "dev": true
     },
     "cross-spawn": {
@@ -2557,6 +2846,12 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
+    "eventemitter3": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "dev": true
+    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -2607,6 +2902,12 @@
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.5.tgz",
       "integrity": "sha512-WIWGi2L3DyTUvUrwRKgGi9TwxQMUEqPOPQBVi71R96jZXJdFskXEmf54BoZaS1kknGODoIGASGEzBUYdyMCBJg==",
+      "dev": true
+    },
+    "follow-redirects": {
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "dev": true
     },
     "fs.realpath": {
@@ -2717,6 +3018,62 @@
       "dev": true,
       "requires": {
         "has-symbols": "^1.0.2"
+      }
+    },
+    "he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true
+    },
+    "html-encoding-sniffer": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-3.0.0.tgz",
+      "integrity": "sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==",
+      "dev": true,
+      "requires": {
+        "whatwg-encoding": "^2.0.0"
+      }
+    },
+    "http-proxy": {
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/http-proxy/-/http-proxy-1.18.1.tgz",
+      "integrity": "sha512-7mz/721AbnJwIVbnaSv1Cz3Am0ZLT/UBwkC92VlxhXv/k/BBQfM2fXElQNC27BVGr0uwUpplYPQM9LnaBMR5NQ==",
+      "dev": true,
+      "requires": {
+        "eventemitter3": "^4.0.0",
+        "follow-redirects": "^1.0.0",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "http-server": {
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/http-server/-/http-server-14.1.1.tgz",
+      "integrity": "sha512-+cbxadF40UXd9T01zUHgA+rlo2Bg1Srer4+B4NwIHdaGxAGGv59nYRnGGDJ9LBk7alpS0US+J+bLLdQOOkJq4A==",
+      "dev": true,
+      "requires": {
+        "basic-auth": "^2.0.1",
+        "chalk": "^4.1.2",
+        "corser": "^2.0.1",
+        "he": "^1.2.0",
+        "html-encoding-sniffer": "^3.0.0",
+        "http-proxy": "^1.18.1",
+        "mime": "^1.6.0",
+        "minimist": "^1.2.6",
+        "opener": "^1.5.1",
+        "portfinder": "^1.0.28",
+        "secure-compare": "3.0.1",
+        "union": "~0.5.0",
+        "url-join": "^4.0.1"
+      }
+    },
+    "iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
       }
     },
     "ignore": {
@@ -2943,6 +3300,12 @@
         "path-exists": "^3.0.0"
       }
     },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
+    },
     "lodash.merge": {
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
@@ -2959,6 +3322,12 @@
         "yallist": "^4.0.0"
       }
     },
+    "mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "dev": true
+    },
     "minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2973,6 +3342,15 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
       "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.6"
+      }
     },
     "ms": {
       "version": "2.1.2",
@@ -3029,6 +3407,12 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true
     },
     "optionator": {
       "version": "0.9.1",
@@ -3101,6 +3485,28 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
+    "portfinder": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
+      "integrity": "sha512-Se+2isanIcEqf2XMHjyUKskczxbPH7dQnlMjXX6+dybayyHvAf/TCgyMRlzf/B6QDhAEFOGes0pzRo3by4AbMA==",
+      "dev": true,
+      "requires": {
+        "async": "^2.6.2",
+        "debug": "^3.1.1",
+        "mkdirp": "^0.5.5"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.2.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
+          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        }
+      }
+    },
     "prelude-ls": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
@@ -3113,10 +3519,25 @@
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
       "dev": true
     },
+    "qs": {
+      "version": "6.10.5",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.5.tgz",
+      "integrity": "sha512-O5RlPh0VFtR78y79rgcgKK4wbAI0C5zGVLztOIdpWX6ep368q5Hv6XRxDvXuZ9q3C6v+e3n8UfZZJw7IIG27eQ==",
+      "dev": true,
+      "requires": {
+        "side-channel": "^1.0.4"
+      }
+    },
     "regexpp": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
+      "dev": true
+    },
+    "requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
       "dev": true
     },
     "resolve": {
@@ -3144,6 +3565,24 @@
       "requires": {
         "glob": "^7.1.3"
       }
+    },
+    "safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "secure-compare": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/secure-compare/-/secure-compare-3.0.1.tgz",
+      "integrity": "sha512-AckIIV90rPDcBcglUwXPF3kg0P0qmPsPXAj6BBEENQE1p5yA1xfmDJzfi1Tappj37Pv2mVbKpL3Z1T+Nn7k1Qw==",
+      "dev": true
     },
     "semver": {
       "version": "6.3.0",
@@ -3269,6 +3708,15 @@
         "which-boxed-primitive": "^1.0.2"
       }
     },
+    "union": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/union/-/union-0.5.0.tgz",
+      "integrity": "sha512-N6uOhuW6zO95P3Mel2I2zMsbsanvvtgn6jVqJv4vbVcz/JN0OkL9suomjQGmWtxJQXOCqUJvquc1sMeNz/IwlA==",
+      "dev": true,
+      "requires": {
+        "qs": "^6.4.0"
+      }
+    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -3278,11 +3726,26 @@
         "punycode": "^2.1.0"
       }
     },
+    "url-join": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
+      "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
+      "dev": true
+    },
     "v8-compile-cache": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.2.0.tgz",
       "integrity": "sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==",
       "dev": true
+    },
+    "whatwg-encoding": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-2.0.0.tgz",
+      "integrity": "sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==",
+      "dev": true,
+      "requires": {
+        "iconv-lite": "0.6.3"
+      }
     },
     "which": {
       "version": "2.0.2",

--- a/docs/package.json
+++ b/docs/package.json
@@ -3,16 +3,17 @@
   "version": "1.0.0",
   "description": "UI service is created using vanilla HTML and JS together with bootstrap for CSS.",
   "main": "index.js",
-  "dependencies": {},
   "devDependencies": {
     "eslint": "^8.17.0",
     "eslint-config-standard": "^17.0.0",
     "eslint-plugin-import": "^2.22.1",
     "eslint-plugin-node": "^11.1.0",
-    "eslint-plugin-promise": "^6.0.0"
+    "eslint-plugin-promise": "^6.0.0",
+    "http-server": "^14.1.1"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start-local": "http-server"
   },
   "repository": {
     "type": "git",

--- a/docs/results.html
+++ b/docs/results.html
@@ -120,6 +120,7 @@
 
 
 <!-- Moshan scripts -->
+<script src="/includes/js/common/config.js"></script>
 <script src="/includes/js/common/navbar.js"></script>
 
 <script src="/includes/js/results.js"></script>

--- a/docs/results.html
+++ b/docs/results.html
@@ -15,17 +15,8 @@
     <!-- Axios -->
     <script src="https://unpkg.com/axios/dist/axios.min.js"></script>
 
-    <!-- Moshan scripts -->
-    <script src="/includes/js/common/token.js"></script>
-    <script src="/includes/js/api/common.js"></script>
-
-    <script src="/includes/js/api/tvmaze.js"></script>
-    <script src="/includes/js/api/mal.js"></script>
-    <script src="/includes/js/api/tmdb.js"></script>
-
     <!-- Moshan CSS -->
     <link rel="stylesheet" href="/includes/css/style.css">
-
 
     <!-- Font Awesome Icons -->
     <script src="https://kit.fontawesome.com/f013262c1a.js" crossorigin="anonymous"></script>
@@ -33,53 +24,7 @@
     <title>Moshan - Results</title>
 </head>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
-    <a class="navbar-brand" href="/index.html">
-      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
-            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarToggler">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/index.html">Home</a>
-            </li>
-        </ul>
-
-        <ul class="navbar-nav">
-            <li class="nav-item mr-3">
-                <form class="form-inline" action="/results.html">
-                    <div class="input-group">
-                        <input type="text" class="form-control" placeholder="Search" name="search">
-                        <div class="input-group-prepend">
-                            <button class="btn btn-success" type="submit">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </li>
-
-            <li class="nav-item dropdown">
-              <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false"></a>
-              <ul class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
-                <li><a class="dropdown-item" href="/unwatched.html">Unwatched</a></li>
-                <li><a class="dropdown-item" href="/backlog.html">Backlog</a></li>
-                <li><a class="dropdown-item" href="/history.html">History</a></li>
-                <li><hr class="dropdown-divider"></li>
-                <li><a class="dropdown-item text-danger" onclick="logout()" href="#">Logout</a></li>
-              </ul>
-            </li>
-        </ul>
-        <button id="loginButton" onclick="authorize()" class="btn btn-outline-success nav-item" type="submit">
-            <i class="fas fa-sign-in-alt"></i>
-            Login
-        </button>
-    </div>
-</nav>
+<div id="navbar"></div>
 
 <body>
 <div id="logInAlert" class="alert alert-danger d-none" role="alert">
@@ -120,10 +65,7 @@
 
 
 <!-- Moshan scripts -->
-<script src="/includes/js/common/config.js"></script>
-<script src="/includes/js/common/navbar.js"></script>
-
-<script src="/includes/js/results.js"></script>
+<script type="module" src="/includes/js/results.js"></script>
 
 <!-- Boostrap JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/docs/unwatched.html
+++ b/docs/unwatched.html
@@ -18,79 +18,15 @@
     <!-- Moshan CSS -->
     <link rel="stylesheet" href="/includes/css/style.css">
 
-    <!-- Moshan scripts -->
-    <script src="/includes/js/common/token.js"></script>
-
-    <script src="/includes/js/api/common.js"></script>
-
-    <script src="/includes/js/api/moshan.js"></script>
-    <script src="/includes/js/api/tvmaze.js"></script>
-    <script src="/includes/js/api/tmdb.js"></script>
-    <script src="/includes/js/api/mal.js"></script>
-
-
     <!-- Font Awesome Icons -->
     <script src="https://kit.fontawesome.com/f013262c1a.js" crossorigin="anonymous"></script>
 
     <title>Moshan - Unwatched</title>
 </head>
 
-<nav class="navbar navbar-expand-lg navbar-light bg-light px-2">
-    <a class="navbar-brand" href="/index.html">
-      <img src="/includes/icons/logo.svg" class="d-inline-block align-top navbar-logo" alt="moshan_logo">
-    </a>
-    <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarToggler"
-            aria-controls="navbarToggler" aria-expanded="false" aria-label="Toggle navigation">
-          <span class="navbar-toggler-icon"></span>
-    </button>
-
-    <div class="collapse navbar-collapse" id="navbarToggler">
-        <ul class="navbar-nav mr-auto">
-            <li class="nav-item">
-                <a class="nav-link" href="/index.html">Home</a>
-            </li>
-        </ul>
-
-        <ul class="navbar-nav">
-            <li class="nav-item mr-3">
-                <form class="form-inline" action="/results.html">
-                    <div class="input-group">
-                        <input type="text" class="form-control" placeholder="Search" name="search">
-                        <div class="input-group-prepend">
-                            <button class="btn btn-success" type="submit">
-                                <i class="fas fa-search"></i>
-                            </button>
-                        </div>
-                    </div>
-                </form>
-            </li>
-
-            <li class="nav-item dropdown">
-                <a class="nav-link dropdown-toggle" href="#" id="profileDropdown" role="button"
-                   data-bs-toggle="dropdown" aria-expanded="false"></a>
-                <div class="dropdown-menu pull-right" aria-labelledby="navbarDropdown">
-                    <a class="dropdown-item" href="/unwatched.html">Unwatched</a>
-                    <a class="dropdown-item" href="/backlog.html">Backlog</a>
-                    <a class="dropdown-item" href="/history.html">History</a>
-                    <div class="dropdown-divider"></div>
-                    <a class="dropdown-item text-danger" onclick="logout()" href="#">Logout</a>
-                </div>
-            </li>
-        </ul>
-        <button id="loginButton" onclick="authorize()" class="btn btn-outline-success nav-item" type="submit">
-            <i class="fas fa-sign-in-alt"></i>
-            Login
-        </button>
-    </div>
-</nav>
+<div id="navbar"></div>
 
 <body>
-<div id="logInAlert" class="alert alert-danger d-none" role="alert">
-    Need to be logged in before accessing watch history
-</div>
-<div id="itemsLoadingAlert" class="alert alert-warning d-none" role="alert">
-    Some watch history items are still loading
-</div>
 
 <div class="card">
     <div class="card-header">
@@ -107,10 +43,7 @@
 </footer>
 
 <!-- Moshan scripts -->
-<script src="/includes/js/common/config.js"></script>
-<script src="/includes/js/common/navbar.js"></script>
-
-<script src="/includes/js/unwatched.js"></script>
+<script type="module" src="/includes/js/unwatched.js"></script>
 
 <!-- Boostrap JavaScript -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"

--- a/docs/unwatched.html
+++ b/docs/unwatched.html
@@ -107,6 +107,7 @@
 </footer>
 
 <!-- Moshan scripts -->
+<script src="/includes/js/common/config.js"></script>
 <script src="/includes/js/common/navbar.js"></script>
 
 <script src="/includes/js/unwatched.js"></script>

--- a/template.yml
+++ b/template.yml
@@ -16,6 +16,9 @@ Parameters:
     Type: String
     Default: python3.9
 
+  LocalCognitoClient:
+    Type: String
+
 
 Resources:
   Certificate:
@@ -79,6 +82,7 @@ Resources:
               issuer: !Sub "https://cognito-idp.eu-west-1.amazonaws.com/${CognitoUserPool}"
               audience:
                 - !Ref CognitoClient
+                - !Ref LocalCognitoClient
         DefaultAuthorizer: cognito
       CorsConfiguration:
         AllowHeaders:
@@ -91,6 +95,7 @@ Resources:
           - "DELETE"
         AllowOrigins:
           - !Sub "https://${DomainName}"
+          - "http://localhost:8080"
       DisableExecuteApiEndpoint: true
       Domain:
         CertificateArn: !Ref Certificate


### PR DESCRIPTION
* Use javascript modules instead of importing all the needed files in html code
* Refactor navbar into one HTML file loaded by the `navbar.js` script
* Add new `config.js` including cognito clientID and redirect URL
* Make it possible to override `config.js` with `configLocal.js` changing the default values
* Add `http-server` npm package for running frontend locally
* Make more use of api cache on item page (for added items use the cache rather then calling the external API)
* Change HTML `onclick` properties to JS event listeners
* Change some of the HTML code inside of JS into DOM objects created using `document`
* Move out authentication related code from `navbar.js` to a new `auth.js` file